### PR TITLE
Not using borrow and stolen variables anymore

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -263,15 +263,15 @@ namespace xt
     }
 
     template <class T>
-    inline pyarray<T>::pyarray(pybind11::handle h, pybind11::object::borrowed_t)
-        : base_type(h, pybind11::object::borrowed)
+    inline pyarray<T>::pyarray(pybind11::handle h, pybind11::object::borrowed_t b)
+        : base_type(h, b)
     {
         init_from_python();
     }
 
     template <class T>
-    inline pyarray<T>::pyarray(pybind11::handle h, pybind11::object::stolen_t)
-        : base_type(h, pybind11::object::stolen)
+    inline pyarray<T>::pyarray(pybind11::handle h, pybind11::object::stolen_t s)
+        : base_type(h, s)
     {
         init_from_python();
     }

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -132,14 +132,14 @@ namespace xt
     }
 
     template <class D>
-    inline pycontainer<D>::pycontainer(pybind11::handle h, borrowed_t)
-        : pybind11::object(h, borrowed)
+    inline pycontainer<D>::pycontainer(pybind11::handle h, borrowed_t b)
+        : pybind11::object(h, b)
     {
     }
 
     template <class D>
-    inline pycontainer<D>::pycontainer(pybind11::handle h, stolen_t)
-        : pybind11::object(h, stolen)
+    inline pycontainer<D>::pycontainer(pybind11::handle h, stolen_t s)
+        : pybind11::object(h, s)
     {
     }
     

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -176,15 +176,15 @@ namespace xt
     }
 
     template <class T, std::size_t N>
-    inline pytensor<T, N>::pytensor(pybind11::handle h, pybind11::object::borrowed_t)
-        : base_type(h, pybind11::object::borrowed)
+    inline pytensor<T, N>::pytensor(pybind11::handle h, pybind11::object::borrowed_t b)
+        : base_type(h, b)
     {
         init_from_python();
     }
 
     template <class T, std::size_t N>
-    inline pytensor<T, N>::pytensor(pybind11::handle h, pybind11::object::stolen_t)
-        : base_type(h, pybind11::object::stolen)
+    inline pytensor<T, N>::pytensor(pybind11::handle h, pybind11::object::stolen_t s)
+        : base_type(h, s)
     {
         init_from_python();
     }


### PR DESCRIPTION
As prescribed in https://github.com/pybind/pybind11/issues/777#issuecomment-292313847.