### PR TITLE
Python 2 testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,8 @@ install:
   - conda info -a
   - conda install gtest cmake -c conda-forge
   - conda install xtensor==0.8.3 pytest numpy pybind11==2.1.1 -c conda-forge
-  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\Library -DBUILD_TESTS=ON .
+  - "set PYTHONHOME=%MINICONDA%"
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\Library -D BUILD_TESTS=ON -D PYTHON_EXECUTABLE=%MINICONDA%\\python.exe .
   - nmake test_xtensor_python
   - nmake install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-      env: COMPILER=gcc GCC=4.9
+      env: COMPILER=gcc GCC=4.9 PY=3
     - os: linux
       addons:
         apt:
@@ -16,7 +16,15 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-      env: COMPILER=gcc GCC=5
+      env: COMPILER=gcc GCC=5 PY=3
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env: COMPILER=gcc GCC=5 PY=2
     - os: linux
       addons:
         apt:
@@ -25,7 +33,7 @@ matrix:
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
-      env: COMPILER=clang CLANG=3.6
+      env: COMPILER=clang CLANG=3.6 PY=3
     - os: linux
       addons:
         apt:
@@ -34,7 +42,7 @@ matrix:
             - llvm-toolchain-precise-3.7
           packages:
             - clang-3.7
-      env: COMPILER=clang CLANG=3.7
+      env: COMPILER=clang CLANG=3.7 PY=3
     - os: linux
       addons:
         apt:
@@ -43,10 +51,11 @@ matrix:
             - llvm-toolchain-precise-3.8
           packages:
             - clang-3.8
-      env: COMPILER=clang CLANG=3.8
+      env: COMPILER=clang CLANG=3.8 PY=3
     - os: osx
       osx_image: xcode8
       compiler: clang
+      env: PY=3
 env:
   global:
     - MINCONDA_VERSION="latest"
@@ -73,7 +82,11 @@ install:
       elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         MINCONDA_OS=$MINCONDA_OSX;
       fi
-    - wget "http://repo.continuum.io/miniconda/Miniconda3-$MINCONDA_VERSION-$MINCONDA_OS.sh" -O miniconda.sh;
+    - if [[ "$PY" == "3" ]]; then
+          wget "http://repo.continuum.io/miniconda/Miniconda3-$MINCONDA_VERSION-$MINCONDA_OS.sh" -O miniconda.sh;
+      else
+          wget "http://repo.continuum.io/miniconda/Miniconda2-$MINCONDA_VERSION-$MINCONDA_OS.sh" -O miniconda.sh;
+      fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
@@ -86,7 +99,7 @@ install:
     - conda env create -f ./test-environment.yml
     - source activate test-xtensor-python
     - cd ..
-    - cmake -DBUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda .
+    - cmake -D BUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda .
     - make -j2 test_xtensor_python
     - make install
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -29,7 +29,7 @@ Example 1: Use an algorithm of the C++ library on a numpy array inplace
 
     PYBIND11_PLUGIN(xtensor_python_test)
     {
-        import_array() //this is actually a macro
+        import_numpy() //this is actually a macro
         pybind11::module m("xtensor_python_test", "Test module for xtensor python bindings");
 
         m.def("sum_of_sines", sum_of_sines,
@@ -80,7 +80,7 @@ Example 2: Create a universal function from a C++ scalar function
 
     PYBIND11_PLUGIN(xtensor_python_test)
     {
-        import_array()
+        import_numpy()
         py::module m("xtensor_python_test", "Test module for xtensor python bindings");
 
         m.def("vectorized_func", xt::pyvectorize(scalar_func), "");

--- a/docs/source/numpy_capi.rst
+++ b/docs/source/numpy_capi.rst
@@ -17,7 +17,7 @@ When writing an extension module that is self-contained in a single file, its au
 points:
 
 - ``FORCE_IMPORT_ARRAY`` must be defined before including any header of ``xtensor-python``.
-- ``import_array()`` must be called in the function initializing the module.
+- ``import_numpy()`` must be called in the function initializing the module.
 
 Thus the basic skeleton of the module looks like:
 
@@ -29,7 +29,7 @@ Thus the basic skeleton of the module looks like:
 
     PYBIND11_PLUGIN(plugin_name)
     {
-        import_array()
+        import_numpy()
         pybind11::module m(//...
         //...
         return m.ptr();

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -24,9 +24,12 @@
 #define PY_ARRAY_UNIQUE_SYMBOL xtensor_python_ARRAY_API
 #endif
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
 #include "numpy/arrayobject.h"
 
 #include "xtensor/xcontainer.hpp"
+
+#define import_numpy() { if (_import_array() < 0) {PyErr_Print(); PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import"); } }
 
 namespace xt
 {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
 {
     // Initialize all the things (google-test and Python interpreter)
     Py_Initialize();
-    import_array()
+    import_numpy()
     ::testing::InitGoogleTest(&argc, argv);
 
     // Run test suite

--- a/test_python/main.cpp
+++ b/test_python/main.cpp
@@ -51,7 +51,7 @@ int add(int i, int j)
 
 PYBIND11_PLUGIN(xtensor_python_test)
 {
-    import_array()
+    import_numpy()
     py::module m("xtensor_python_test", "Test module for xtensor python bindings");
 
     m.def("example1", example1);


### PR DESCRIPTION
CC@JohanMabille the problem was that the `import_array` macro has a return statement which causes the compiler to believe that it is a return statement for the enclosing function.

With Python 3, the return type of that statement is int, which if fine for the `main()` function and the pybind definition module. With Python 2, the return type is void, which causes the compilation to fail.