### PR TITLE
iterator::operator[] is const

### DIFF
--- a/include/xtensor-python/pystrides_adaptor.hpp
+++ b/include/xtensor-python/pystrides_adaptor.hpp
@@ -79,7 +79,7 @@ namespace xt
         inline reference operator*() const { return *p_current / N; }
         inline pointer operator->() const { return p_current; }
 
-        inline reference operator[](difference_type n) { return *(p_current + n) / N; }
+        inline reference operator[](difference_type n) const { return *(p_current + n) / N; }
 
         inline self_type& operator++()
         {


### PR DESCRIPTION
This solves the build failure of the cookiecutter with the latest xtensor (0.10.9)