### PR TITLE
Adjustments for xtensor 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ from the `docs` subdirectory.
 | `xtensor-python`  | `xtensor`  |  `pybind11` |
 |-------------------|------------|-------------|
 | master            |  ^0.10.9   | ^2.1.0      |
-| 0.12.x            |  ^0.10.2   | ^2.1.0      |
-| 0.11.x            |  ^0.10.0   | ^2.1.0      |
-| 0.10.x            |  ^0.9.0    | ^2.1.0      |
-| 0.9.x             |  ^0.8.1    | ^2.1.0      |
+| 0.12.x            |  ^0.10.2   | 2.1.\*      |
+| 0.11.x            |  ^0.10.0   | 2.1.\*      |
+| 0.10.x            |  ^0.9.0    | 2.1.\*      |
+| 0.9.x             |  ^0.8.1    | 2.1.\*      |
 
 These dependencies are automatically resolved when using the conda package manager.
 

--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -113,6 +113,7 @@ namespace xt
         using inner_strides_type = pystrides_adaptor<sizeof(T)>;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = pyarray<T>;
+        static constexpr layout_type layout = layout_type::dynamic;
     };
 
     /**
@@ -386,7 +387,7 @@ namespace xt
      */
     template <class T>
     inline pyarray<T>::pyarray(const self_type& rhs)
-        : base_type()
+        : base_type(), semantic_base(rhs)
     {
         auto tmp = pybind11::reinterpret_steal<pybind11::object>(
             PyArray_NewLikeArray(rhs.python_array(), NPY_KEEPORDER, nullptr, 1));

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -13,7 +13,6 @@
 #include <functional>
 #include <numeric>
 
-#include "pybind11/common.h"
 #include "pybind11/complex.h"
 #include "pybind11/pybind11.h"
 

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -94,6 +94,7 @@ namespace xt
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
         using temporary_type = pytensor<T, N>;
+        static constexpr layout_type layout = layout_type::dynamic;
     };
 
     /**


### PR DESCRIPTION
Required changes in `xtensor-python` headers

 - to work with xtensor 0.11.
 - to work with pybind11 2.2.0.

without breaking xtensor `0.10.*` support.