### PR TITLE
support char arrays and complicated dtypes (structs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
     - conda update -q conda
     # Useful for debugging any issues with conda
     - conda info -a
-    - conda install pytest numpy pybind11==2.2.3 -c conda-forge
+    - conda install pytest numpy pybind11==2.2.1 -c conda-forge
     - conda install cmake gtest -c conda-forge
     - conda install xtensor==0.16.0 -c QuantStack
     - cmake -D BUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda .

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
     - conda update -q conda
     # Useful for debugging any issues with conda
     - conda info -a
-    - conda install pytest numpy pybind11==2.2.1 -c conda-forge
+    - conda install pytest numpy pybind11==2.2.3 -c conda-forge
     - conda install cmake gtest -c conda-forge
     - conda install xtensor==0.16.0 -c QuantStack
     - cmake -D BUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda .

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -225,7 +225,7 @@ namespace xt
         template <class T>
         bool check_array(const pybind11::handle& src)
         {
-            using is_arithmetic_type = std::integral_constant<bool, !!pybind11::detail::satisfies_any_of<T, std::is_arithmetic, xtl::is_complex>::value>;
+            using is_arithmetic_type = std::integral_constant<bool, bool(pybind11::detail::satisfies_any_of<T, std::is_arithmetic, xtl::is_complex>::value)>;
             return PyArray_Check(src.ptr()) &&
                    check_array_type<T>(src, is_arithmetic_type{});
         }

--- a/test_python/main.cpp
+++ b/test_python/main.cpp
@@ -7,7 +7,6 @@
 ****************************************************************************/
 
 #include <numeric>
-#include <limits>
 
 #include "xtensor/xmath.hpp"
 #include "xtensor/xarray.hpp"
@@ -133,7 +132,9 @@ xt::pyarray<A> dtype_to_python()
 xt::pyarray<B> dtype_from_python(xt::pyarray<B>& b)
 {
     if (b(0).a != 1 || b(0).b != 'p' || b(1).a != 123 || b(1).b != 'c')
+    {
         throw std::runtime_error("FAIL");
+    }
 
     b(0).a = 123.;
     b(0).b = 'w';

--- a/test_python/test_pyarray.py
+++ b/test_python/test_pyarray.py
@@ -9,7 +9,6 @@
 import os
 import sys
 import subprocess
-import gc
 
 # Build the test extension
 
@@ -92,10 +91,12 @@ class XtensorTest(TestCase):
         var = xt.dtype_to_python()
         self.assertEqual(var.dtype.names, ('a', 'b', 'c', 'x'))
 
-        exp_dtype = {'a': (np.dtype('float64'), 0),
-                     'b': (np.dtype('int32'), 8),
-                     'c': (np.dtype('int8'), 12),
-                     'x': (np.dtype(('<f8', (3,))), 16)}
+        exp_dtype = {
+             'a': (np.dtype('float64'), 0),
+             'b': (np.dtype('int32'), 8),
+             'c': (np.dtype('int8'), 12),
+             'x': (np.dtype(('<f8', (3,))), 16)
+        }
 
         self.assertEqual(var.dtype.fields, exp_dtype)
 


### PR DESCRIPTION
This adds support for char arrays:

```python
arr = np.array(["hallo", "test", "123123"], dtype=np.dtype('|S20'))
```

```cpp
void test_chars(xt::pyarray<char[20]>& arr)
{
    std::cout << arr(0) << std::endl;
}
```

It also adds some initial dtype support (i.e. you can declare structs, use them inside C++ and serialize them from numpy). However, pybind has a lot of code that deals with padding differences from C++ / NumPy which I haven't really looked at.

This code also removes our own typenum stuff as well as switching to use `PyArray_EquivTypes` instead of comparing the typenums. There is a good chance that comparing typenums is faster. Therefore, we could statically enable typenums if we know (from the C++ type) that a statically determinable typenum is available.

@iamthebot you might be interested in this based off of your question in #142 