### PR TITLE
Nicer names when printing function arguments

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -36,7 +36,7 @@ namespace pybind11
         {
             static PYBIND11_DESCR name()
             {
-                return _("numpy.ndarray[") + make_caster<T>::name() + _("]");
+                return _("numpy.ndarray[") + npy_format_descriptor<T>::name() + _("]");
             }
         };
 

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -37,7 +37,7 @@ namespace pybind11
         {
             static PYBIND11_DESCR name()
             {
-                return _("numpy.ndarray[") + make_caster<T>::name() + _("]");
+                return _("numpy.ndarray[") + npy_format_descriptor<T>::name() + _("]");
             }
         };
 


### PR DESCRIPTION
This changes the name generation function for pyarrays so that we use the numpy name printing facility from pybind11 which prints names such as int32 / int64 / float32 etc.