### PR TITLE
Added include for the generated xtensor-pythonTargets.cmake.

### DIFF
--- a/xtensor-pythonConfig.cmake.in
+++ b/xtensor-pythonConfig.cmake.in
@@ -15,7 +15,7 @@
 
 @PACKAGE_INIT@
 
-set(PN xtensor-python)
-set_and_check(${PN}_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set(${PN}_LIBRARY "")
-check_required_components(${PN})
+if(NOT TARGET @PROJECT_NAME@)
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+  get_target_property(@PROJECT_NAME@_INCLUDE_DIRS xtensor-python INTERFACE_INCLUDE_DIRECTORIES)
+endif()


### PR DESCRIPTION
The previous version of `xtensor-pythonConfig.cmake.in` didn't properly include the generated xtensor-pythonTargets.cmake file. Thus users were not able to use the imported target xtensor-python.