### PR TITLE
Support pybind11 master branch (2.3 dev)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ before_install:
       elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         export CXX=clang++ CC=clang PYTHONHOME=$HOME/miniconda;
       fi
+    - PYBIND11_VERSION=${PYBIND11_VERSION:-2.2.1}
 
 install:
     # Define the version of miniconda to download
@@ -126,8 +127,26 @@ install:
     - conda update -q conda
     # Useful for debugging any issues with conda
     - conda info -a
-    - conda install pytest numpy pybind11==2.2.1 -c conda-forge
+    - conda install pytest numpy -c conda-forge
     - conda install cmake gtest -c conda-forge
+    - |
+      if [[ "$PYBIND11_VERSION" == "master" ]]; then
+        conda_root=$(cd $(dirname $(which conda))/.. && pwd)
+        mkdir -p $conda_root/tmp
+        cd $conda_root/tmp
+        curl -sSL -o pybind11.tar.gz https://github.com/pybind/pybind11/archive/master.tar.gz
+        rm -rf pybind11-master
+        tar xf pybind11.tar.gz
+        cd pybind11-master
+        python setup.py install
+        mkdir -p build
+        cd build
+        cmake -DPYBIND11_TEST=OFF -DPYTHON_EXECUTABLE:FILEPATH=`which python` -DCMAKE_INSTALL_PREFIX=${conda_root} ..
+        make install
+        cd $TRAVIS_BUILD_DIR
+      else
+        conda install pybind11==${PYBIND11_VERSION} -c conda-forge
+      fi
     - conda install xtensor==0.17.3 -c QuantStack
     - cmake -D BUILD_TESTS=ON -D CMAKE_INSTALL_PREFIX=$HOME/miniconda -D PYTHON_EXECUTABLE=$PY_EXE .
     - make -j2 test_xtensor_python

--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -31,6 +31,7 @@ namespace pybind11
 {
     namespace detail
     {
+#ifdef PYBIND11_DESCR // The macro is removed from pybind11 since 2.3
         template <class T, xt::layout_type L>
         struct handle_type_name<xt::pyarray<T, L>>
         {
@@ -39,6 +40,7 @@ namespace pybind11
                 return _("numpy.ndarray[") + npy_format_descriptor<T>::name() + _("]");
             }
         };
+#endif
 
         template <typename T, xt::layout_type L>
         struct pyobject_caster<xt::pyarray<T, L>>
@@ -63,7 +65,11 @@ namespace pybind11
                 return src.inc_ref();
             }
 
+#ifdef PYBIND11_DESCR // The macro is removed from pybind11 since 2.3
             PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name());
+#else
+            PYBIND11_TYPE_CASTER(type, _("numpy.ndarray[") + npy_format_descriptor<T>::name + _("]"));
+#endif
         };
 
         // Type caster for casting ndarray to xexpression<pyarray>

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -32,6 +32,7 @@ namespace pybind11
 {
     namespace detail
     {
+#ifdef PYBIND11_DESCR // The macro is removed from pybind11 since 2.3
         template <class T, std::size_t N, xt::layout_type L>
         struct handle_type_name<xt::pytensor<T, N, L>>
         {
@@ -40,6 +41,7 @@ namespace pybind11
                 return _("numpy.ndarray[") + npy_format_descriptor<T>::name() + _("]");
             }
         };
+#endif
 
         template <class T, std::size_t N, xt::layout_type L>
         struct pyobject_caster<xt::pytensor<T, N, L>>
@@ -65,7 +67,11 @@ namespace pybind11
                 return src.inc_ref();
             }
 
+#ifdef PYBIND11_DESCR // The macro is removed from pybind11 since 2.3
             PYBIND11_TYPE_CASTER(type, handle_type_name<type>::name());
+#else
+            PYBIND11_TYPE_CASTER(type, _("numpy.ndarray[") + npy_format_descriptor<T>::name + _("]"));
+#endif
         };
 
         // Type caster for casting ndarray to xexpression<pytensor>

--- a/include/xtensor-python/xtensor_type_caster_base.hpp
+++ b/include/xtensor-python/xtensor_type_caster_base.hpp
@@ -157,10 +157,12 @@ namespace pybind11
                 return cast_impl(src, policy, parent);
             }
 
+#ifdef PYBIND11_DESCR // The macro is removed from pybind11 since 2.3
             static PYBIND11_DESCR name()
             {
                 return _("xt::xtensor");
             }
+#endif
 
             template <typename T>
             using cast_op_type = cast_op_type<T>;


### PR DESCRIPTION
The macro `PYBIND11_DESCR` is removed from pybind11 master [(it happened more than a year ago)](https://github.com/pybind/pybind11/commit/c10ac6cf1f69ebe2b7dd26957325ea3b161cb7ff#diff-da0ffd610309c15faf10ee811e1ae4abL104).  This is a hack to allow xtensor-python to build.

For testing I tweaked the `.travis.yml`.  Set PYBIND11_VERSION=master environment variable in Travis CI to enable pybind11 master branch.