### PR TITLE
Abort array/tensor construction if pyobject is not valid

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -744,6 +744,11 @@ namespace xt
     template <class T, layout_type L>
     inline void pyarray<T, L>::init_from_python()
     {
+        if (!static_cast<bool>(*this))
+        {
+            return;
+        }
+        
         m_shape = inner_shape_type(reinterpret_cast<size_type*>(PyArray_SHAPE(this->python_array())),
                                    static_cast<size_type>(PyArray_NDIM(this->python_array())));
         m_strides = inner_strides_type(reinterpret_cast<difference_type*>(PyArray_STRIDES(this->python_array())),

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -442,6 +442,11 @@ namespace xt
     template <class T, std::size_t N, layout_type L>
     inline void pytensor<T, N, L>::init_from_python()
     {
+        if (!static_cast<bool>(*this))
+        {
+            return;
+        }
+        
         if (PyArray_NDIM(this->python_array()) != N)
         {
             throw std::runtime_error("NumPy: ndarray has incorrect number of dimensions");


### PR DESCRIPTION
This PR fixes #174.

Currently when pybind11 tries to cast a `pyobject`, that is not compatible with the ndarray interface, into a `pyarray` (or a `pytensor`), the custom type caster ends up building a `pyarray` based on an invalid `pyobject` (pointing to `null`). This leads to a segfault when `init_from_python` is called in the contructor.

The proposed solution is to abort the function `init_from_python` if the underlying `pyobject` is invalid.

Note that the constructed `pyarray` object will itself be invalid, which is consistent with the base class `pyobject` but probably not with the `xtensor` usual behavior. Another possibility could be to throw an exception or to change the validation logic of the type caster.