### PR TITLE
Bring pyarray and pytensor up to date with xtensor 0.20.0

### DIFF
--- a/include/xtensor-python/pyarray.hpp
+++ b/include/xtensor-python/pyarray.hpp
@@ -293,6 +293,9 @@ namespace xt
     struct xcontainer_inner_types<pyarray<T, L>>
     {
         using storage_type = xbuffer_adaptor<T*>;
+        using reference = typename storage_type::reference;
+        using const_reference = typename storage_type::const_reference;
+        using size_type = typename storage_type::size_type;
         using shape_type = std::vector<typename storage_type::size_type>;
         using strides_type = std::vector<typename storage_type::difference_type>;
         using backstrides_type = pyarray_backstrides<pyarray<T, L>>;

--- a/include/xtensor-python/pytensor.hpp
+++ b/include/xtensor-python/pytensor.hpp
@@ -112,6 +112,9 @@ namespace xt
     struct xcontainer_inner_types<pytensor<T, N, L>>
     {
         using storage_type = xbuffer_adaptor<T*>;
+        using reference = typename storage_type::reference;
+        using const_reference = typename storage_type::const_reference;
+        using size_type = typename storage_type::size_type;
         using shape_type = std::array<npy_intp, N>;
         using strides_type = shape_type;
         using backstrides_type = shape_type;


### PR DESCRIPTION
In https://github.com/QuantStack/xtensor/commit/bfa8879a18615ae39874c79a992b4b39843b3ca9 , 3 type aliases introduced to xcontainer_inner_types specialization:

* `using reference = typename storage_type::reference;`
* `using const_reference = typename storage_type::const_reference;`
* `using size_type = typename storage_type::size_type;`

They should be added to xtensor-python to keep it working for xtensor 0.20.0.