### PR TITLE
Explicit long long allocator instantiation

### DIFF
--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -1,0 +1,20 @@
+.. Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht
+
+   Distributed under the terms of the BSD 3-Clause License.
+
+   The full license is in the file LICENSE, distributed with this software.
+
+Compiler workarounds
+====================
+
+This page tracks the workarounds for the various compiler issues that we
+encountered in the development. This is mostly of interest for developers
+interested in contributing to xtensor-python.
+
+GCC and ``std::allocator<long long>``
+-------------------------------------
+
+GCC sometimes fails to automatically instantiate the ``std::allocator``
+class template for the types ``long long`` and ``unsigned long long``.
+Those allocators are thus explicitly instantiated in the dummy function
+``void long_long_allocator()`` in the file ``py_container.hpp``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
 .. toctree::
    :caption: DEVELOPER ZONE
 
+   compilers
    releasing
 
 .. _NumPy: http://www.numpy.org

--- a/include/xtensor-python/pycontainer.hpp
+++ b/include/xtensor-python/pycontainer.hpp
@@ -455,6 +455,18 @@ namespace xt
         }
 #endif
     }
+
+#if defined(__GNUC__) && !defined(__clang__)
+    namespace workaround
+    {
+        // Fixes "undefined symbol" issues
+        inline void long_long_allocator()
+        {
+            std::allocator<long long> a;
+            std::allocator<unsigned long long> b;
+        }
+    }
+#endif
 }
 
 #endif


### PR DESCRIPTION
This fixes undefined symbol issues when building on the manylinux1 docker image (with gcc 7.2).